### PR TITLE
gensys fails without coercing G0, G1 to complex

### DIFF
--- a/src/gensys.jl
+++ b/src/gensys.jl
@@ -91,7 +91,7 @@ end
 
 # method if no div is given
 function gensys(Γ0, Γ1, c, ψ, π)
-    F = schurfact(Γ0, Γ1)
+    F = schurfact(complex(Γ0), complex(Γ1))
     div = new_div(F)
     gensys(F, c, ψ, π, div)
 end
@@ -99,7 +99,7 @@ end
 
 # method if all arguments are given
 function gensys(Γ0, Γ1, c, ψ, π, div)
-    F = schurfact(Γ0, Γ1)
+    F = schurfact(complex(Γ0), complex(Γ1))
     gensys(F, c, ψ, π, div)
 end
 

--- a/src/gensys.jl
+++ b/src/gensys.jl
@@ -56,7 +56,10 @@ only with not-s.c. z; eu=[-2,-2] for coincident zeros.
 =#
 
 module GenSys
-include("ordered_qz.jl")
+
+if VERSION <= v"0.4-"
+    include("ordered_qz.jl")
+end
 
 export gensys
 


### PR DESCRIPTION
Wise lessons learned from the DSGE.jl project. Otherwise, we get a SingularException taking an inverse down the road.
